### PR TITLE
Always include AWS CLI for Rails projects

### DIFF
--- a/base/rails/Dockerfile
+++ b/base/rails/Dockerfile
@@ -41,10 +41,10 @@ WORKDIR /app
 ENV DEBIAN_FRONTEND="noninteractive"
 
 # Common dependencies
-ONBUILD RUN \
+RUN \
     # Using --mount to speed up build with caching, see https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mount
-    --mount=type=cache,id=apt-cache-${RAILS_ENV},target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=apt-lib-${RAILS_ENV},target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
     --mount=type=tmpfs,target=/var/log \
     # Remove automatic apt cache Docker cleanup scripts
     rm -f /etc/apt/apt.conf.d/docker-clean; \
@@ -64,15 +64,14 @@ ONBUILD RUN \
     ;
 
 # version of AWS CLI to use for asset uploads
-ONBUILD ARG AWSCLI_VERSION=linux-x86_64-2.14.3
+ARG AWSCLI_VERSION=linux-x86_64-2.14.3
 
 # Install AWS CLI
-ONBUILD RUN if [[ "$RAILS_ENV" = "production" && "$S3_BUCKET_NAME" != "" ]]; then \
-    curl "https://awscli.amazonaws.com/awscli-exe-${AWSCLI_VERSION}.zip" -o "awscli.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-${AWSCLI_VERSION}.zip" -o "awscli.zip" && \
     unzip awscli.zip && \
     ./aws/install; \
-    rm awscli.zip; \
-    fi
+    rm awscli.zip \
+    ;
 
 FROM ruby AS builder
 

--- a/base/rails/Dockerfile
+++ b/base/rails/Dockerfile
@@ -64,7 +64,7 @@ RUN \
     ;
 
 # version of AWS CLI to use for asset uploads
-ARG AWSCLI_VERSION=linux-x86_64-2.14.3
+ARG AWSCLI_VERSION=linux-x86_64-2.26.5
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-${AWSCLI_VERSION}.zip" -o "awscli.zip" && \


### PR DESCRIPTION
I noticed that our deploys were installing the AWS CLI every time. The AWS CLI was not included in all of our Rails builds, because it's used for uploading assets to S3, and some of our Rails projects (the ~~plugs~~ integrations) don't use this feature.

However, we don't include the AWS CLI in the final image:

```
❯ fly ssh console -a yetto-production
Connecting to fdaa:2:5f3:a7b:3c4:2611:e6cc:2... complete
root@e286e676ad64e8:/app# which aws
root@e286e676ad64e8:/app# 
```

I think my intent was to not include the program because it would save us a few MB; but now it's causing us to waste time on every deploy. In this PR I'm installing the AWS CLI by default on the Rails builder image. The projects which need it will use it; and every project (regardless of whether or not they have assets) will dump it later on as part of the final build. 